### PR TITLE
Log actual request object when Set call fails.

### DIFF
--- a/client.go
+++ b/client.go
@@ -179,7 +179,8 @@ func (c *Client) makeRequest(request *batch) {
 		dec.Decode(&response)
 
 		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("HTTP Post Request Failed, Status Code %d: %v", resp.StatusCode, response)
+			return fmt.Errorf("HTTP Post Request Failed, Status Code %d. \nResponse: %v \nRequest payload: %v",
+					resp.StatusCode, response, string(payload))
 		}
 
 		return nil


### PR DESCRIPTION
@segmentio/sources-warehouses 

would've helped today with debugging which request caused a POST error
